### PR TITLE
launches the simulator that is in the xcode version set by xcode-select

### DIFF
--- a/bin/choose_sim_device
+++ b/bin/choose_sim_device
@@ -38,7 +38,8 @@ on run argv
   set simType to item 1 of argv
   set iosVersion to item 2 of argv
 
-  activate application "iPhone Simulator"
+  set xcodePath to do shell script "xcode-select -p"
+  activate application (xcodePath & "Platforms/iPhoneSimulator.platform/Developer/Applications/iPhone Simulator.app/Contents/MacOS/iPhone Simulator")
   tell application "System Events"
     tell process "iOS Simulator"
       tell menu bar 1


### PR DESCRIPTION
Using `activate application "iPhone Simulator"` in AppleScript was launching a different version of Xcode that was not set as the default with `xcode-select`

In my case, it was launching 5.1 Developer Preview instead of 5.0.2

This PR fixes that, but I honestly haven't tested against Xcode <5.

Do you know if the iPhone Simulator file is in the same path for Xcode 4?

Thanks!
