### PR TITLE
Make the build work with Cocoapods [FOR DISCUSSION]

### DIFF
--- a/ui-screen-shooter.sh
+++ b/ui-screen-shooter.sh
@@ -98,27 +98,27 @@ function _xcode {
   if test -n "$(find . -maxdepth 1 -name '*.xcworkspace' -print -quit)"
   then
     base=$(basename *.xcworkspace .xcworkspace)
-	# First build omits PRODUCT_NAME
-	# Do NOT ask me why you need to build this twice for it to work
-	# or how I became to know this fact
+    # First build omits PRODUCT_NAME
+    # Do NOT ask me why you need to build this twice for it to work
+    # or how I became to know this fact
     xcodebuild -sdk "iphonesimulator$ios_version" \
-	  CONFIGURATION_BUILD_DIR="$build_dir/build" \
-	  -workspace $base.xcworkspace -scheme $base -configuration AdHoc \
-	  DSTROOT=$build_dir \
-	  OBJROOT=$build_dir \
-	  SYMROOT=$build_dir \
+      CONFIGURATION_BUILD_DIR="$build_dir/build" \
+      -workspace $base.xcworkspace -scheme $base -configuration AdHoc \
+      DSTROOT=$build_dir \
+      OBJROOT=$build_dir \
+      SYMROOT=$build_dir \
       ONLY_ACTIVE_ARCH=NO \
     "$@"
     xcodebuild -sdk "iphonesimulator$ios_version" \
-	  CONFIGURATION_BUILD_DIR="$build_dir/build" \
+      CONFIGURATION_BUILD_DIR="$build_dir/build" \
       PRODUCT_NAME=app \
-	  -workspace $base.xcworkspace -scheme $base -configuration AdHoc \
-	  DSTROOT=$build_dir \
-	  OBJROOT=$build_dir \
-	  SYMROOT=$build_dir \
+      -workspace $base.xcworkspace -scheme $base -configuration AdHoc \
+      DSTROOT=$build_dir \
+      OBJROOT=$build_dir \
+      SYMROOT=$build_dir \
       ONLY_ACTIVE_ARCH=NO \
     "$@"
-	cp -r "$build_dir/build/app.app" "$build_dir"
+    cp -r "$build_dir/build/app.app" "$build_dir"
   else
     xcodebuild -sdk "iphonesimulator$ios_version" \
       CONFIGURATION_BUILD_DIR=$build_dir \


### PR DESCRIPTION
This update detects if CWD is a Workspace and if so it will try the build the project. This works with my CocoaPods project. It is ugly, hacky, and I have no idea why/how it works. Fixes #26

**Requesting review of this code:** Does it work with your project in the below intended use case? Are you able to simplify the build code used?

INTENDED USAGE:

```
git clone YOURPROJECT myproj
cd myproj
pod
git clone https://github.com/jonathanpenn/ui-screen-shooter.git
vim ./shoot_the_screens.js
ui-screen-shooter/ui-screen-shooter.sh
# Start drinking beer
```

See also
- https://stackoverflow.com/questions/22663294/xcodebuild-fails-when-run-from-jenkins-works-in-terminal
- https://stackoverflow.com/questions/21602965/cocoapods-command-line-build-fails
