### PR TITLE
Un-hardcode Automation trace template path.

### DIFF
--- a/ui-screen-shooter.sh
+++ b/ui-screen-shooter.sh
@@ -148,7 +148,7 @@ function _run_automation {
           in language \"${language}\"..."
 
   dev_tools_dir=`xcode-select -print-path`
-  tracetemplate="$dev_tools_dir/../Applications/Instruments.app/Contents/PlugIns/AutomationInstrument.xrplugin/Contents/Resources/Automation.tracetemplate"
+  tracetemplate="Automation"
 
   # Check out the `unix_instruments.sh` script to see why we need this wrapper.
   DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"


### PR DESCRIPTION
`man instruments` tells us this:

```
-t template
         The path to the template to run

-s [devices, templates]
         Show list of known devices or templates, and then exit ( default is templates )
```

`instruments -s templates` gives us this:

```
Known Templates:
"Activity Monitor"
"Allocations"
"Automation"
"Blank"
"Cocoa Layout"
"Core Animation"
"Core Data"
"Counters"
"Dispatch"
"Energy Diagnostics"
"File Activity"
"GPU Driver"
"Leaks"
"Multicore"
"Network"
"OpenGL ES Analysis"
"Sudden Termination"
"System Trace"
"System Usage"
"Time Profiler"
"UI Recorder"
"Zombies"
```

I’ve tested it, and you can just pass `-t "Automation"` to the `instruments` command and it will work. No need to hardcode the path! Not sure if this is new, but it works on my machine running Xcode 6.0.1.
