### PR TITLE
Fix double extra argument when calling unix_instruments.sh

### DIFF
--- a/ui-screen-shooter.sh
+++ b/ui-screen-shooter.sh
@@ -169,8 +169,7 @@ function _run_automation {
     -e UIARESULTSPATH "$trace_results_dir" \
     -e UIASCRIPT "$automation_script" \
     -AppleLanguages "($language)" \
-    -AppleLocale "$language" \
-    "$@"
+    -AppleLocale "$language"
 
   find $trace_results_dir/Run\ 1/ -name *landscape*png -type f -exec sips -r -90 \{\} \;
 }


### PR DESCRIPTION
The arguments are already being sent to unix_instruments.sh, no need to add the complete list of arguments again, right?
